### PR TITLE
Update source-code link to account for upstream monorepo change

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -76,7 +76,7 @@ description: |
 website: https://proton.me/mail
 contact: https://github.com/pedro-avalos/proton-mail-snap/issues
 issues: https://github.com/pedro-avalos/proton-mail-snap/issues
-source-code: https://github.com/ProtonMail/inbox-desktop
+source-code: https://github.com/ProtonMail/WebClients/tree/main/applications/inbox-desktop
 
 base: core24
 grade: stable


### PR DESCRIPTION
According to the [previously linked repo](https://github.com/ProtonMail/inbox-desktop?tab=readme-ov-file#inbox-desktop-app) there's been a migration of the app to another repository

Related to this, I felt a little uneasy that the [author on snapcraft](https://snapcraft.io/publisher/proton-ag) seems official (even verified) but then the snap description itself mentions this is an unofficial distribution. Is the publisher on snapcraft actually verified by the upstream?